### PR TITLE
Make sure to add Boost include directories for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(
 	${GTEST_INCLUDE_DIRS}
+	${Boost_INCLUDE_DIRS}
 	${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 


### PR DESCRIPTION
This fixes a problem where building the tests fail due to "missing" boost headers since cmake isn't adding the boost include directories for the tests build.
