### PR TITLE
Improve SRC performance

### DIFF
--- a/src/audio/ffmpeg_audio_processor_swresample.h
+++ b/src/audio/ffmpeg_audio_processor_swresample.h
@@ -25,6 +25,7 @@ public:
 		av_opt_set_int(m_swr_ctx, "filter_size", 16, 0);
 		av_opt_set_int(m_swr_ctx, "phase_shift", 8, 0);
 		av_opt_set_int(m_swr_ctx, "linear_interp", 1, 0);
+		av_opt_set_int(m_swr_ctx, "tsf", AV_SAMPLE_FMT_S16P, 0);
 		av_opt_set_double(m_swr_ctx, "cutoff", 0.8, 0);
 	}
 


### PR DESCRIPTION
Reduce the precision of internal SRC computations to improve resampler performance (by about 20-25%) especially on embedded platforms.

Has no effect on the likelihood of finding a fingerprint match.

Some benchmarks for 120s of audio running on a 1gHz ARM7 CPU:
44.1kHz (before): 2.4s
44.1kHz (after): 2s
176.4kHz (before): 7s
176.4kHz (after): 5.6s