### PR TITLE
hide symbols also on first build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ include(CheckCXXCompilerFlag)
 
 find_package(Threads)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+
 check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
 if(COMPILER_SUPPORTS_CXX11)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
@@ -60,7 +62,6 @@ if(APPLE)
 	set(FRAMEWORK_INSTALL_DIR "/Library/Frameworks" CACHE STRING "Directory to install frameworks to")
 endif()
 
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_TOOLS "Build command line tools" OFF)
 option(BUILD_TESTS "Build test suite" OFF)
 


### PR DESCRIPTION
The option to build shared libs was defined after it was checked for the first time, so on the first run it would be undefined and thus evaluating to false.The symbols were therefore not hidden. On a subsequent run of CMake (e.g. by changing any other option or touching CMakeLists.txt) the variable is set from the cache and the visibility option was switched to hidden.