### PR TITLE
Set executable bit for Linux and macOS packaged fpcalc binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,7 @@ jobs:
           for dir in $dirs
           do
             name=$(basename $dir)
+            chmod +x $dir/fpcalc
             tar cvzf release/$name.tar.gz $dir
           done
       - name: Make zips


### PR DESCRIPTION
Just a small addition, as the binaries for macOS and Linux were missing the executable bit. I think because they get packaged into a ZIP file first by the artifacts system of GHA.

As I wanted to avoid the double archive for the artifcats for a single file let's just re-add the bit when packaging the final release archives.