### PR TITLE
Allow build to exclude internal avresample

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set_property(CACHE AUDIO_PROCESSOR_LIB PROPERTY STRINGS avresample swresample)
 set(FFT_LIB CACHE STRING "Library to use for FFT calculations")
 set_property(CACHE FFT_LIB PROPERTY STRINGS avfft fftw3 fftw3f kissfft vdsp)
 
+option(USE_INTERNAL_AVRESAMPLE "Use internal copy of avresample from ffmpeg for input conversion" ON)
+
 include(CMakePushCheckState)
 include(CheckFunctionExists)
 include(CheckCXXCompilerFlag)

--- a/config.h.in
+++ b/config.h.in
@@ -8,6 +8,7 @@
 
 #cmakedefine USE_SWRESAMPLE 1
 #cmakedefine USE_AVRESAMPLE 1
+#cmakedefine USE_INTERNAL_AVRESAMPLE 1
 
 #cmakedefine USE_AVFFT 1
 #cmakedefine USE_FFTW3 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,6 @@ set(chromaprint_SOURCES
 	utils/scope_exit.h
 	utils/rolling_integral_image.h
 	audio/audio_slicer.h
-	avresample/resample2.c
 )
 
 set(chromaprint_PUBLIC_SOURCES chromaprint.cpp)
@@ -63,6 +62,10 @@ endif()
 if(USE_KISSFFT)
 	set(chromaprint_SOURCES fft_lib_kissfft.cpp ${chromaprint_SOURCES} ${KISSFFT_SOURCES})
 	include_directories(${KISSFFT_INCLUDE_DIRS})
+endif()
+
+if (USE_INTERNAL_AVRESAMPLE)
+  set(chromaprint_SOURCES avresample/resample2.c ${chromaprint_SOURCES})
 endif()
 
 add_library(chromaprint_objs OBJECT ${chromaprint_SOURCES})


### PR DESCRIPTION
This allows the build to complete without using FFmpeg-derived code,
though this disables input resampling and thus requires that input
audio to the fingerprinter is already at the configured fingerprint
sample rate.