### PR TITLE
Use check_symbol_exists rather than check_function_exists 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set_property(CACHE FFT_LIB PROPERTY STRINGS avfft fftw3 fftw3f kissfft vdsp)
 
 include(CMakePushCheckState)
 include(CheckFunctionExists)
+include(CheckSymbolExists)
 include(CheckCXXCompilerFlag)
 
 find_package(Threads)
@@ -37,8 +38,8 @@ endif()
 
 cmake_push_check_state(RESET)
 set(CMAKE_REQUIRED_LIBRARIES -lm)
-check_function_exists(lrintf HAVE_LRINTF)
-check_function_exists(round HAVE_ROUND)
+check_symbol_exists(lrintf math.h HAVE_LRINTF)
+check_symbol_exists(round math.h HAVE_ROUND)
 cmake_pop_check_state()
 
 add_definitions(


### PR DESCRIPTION
…to detect math.h functions to support implementations where those are intrinsics, such as Visual Studio 2019 16.10 in some modes.

See https://cmake.org/cmake/help/latest/module/CheckFunctionExists.html :

> Prefer using CheckSymbolExists instead of this module, for the following reasons:
> check_function_exists() can't detect functions that are inlined in headers or specified as a macro.
