### PR TITLE
Add Swift wrapper/bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Bindings, wrappers and reimplementations in other languages:
  * [Scala/JVM](https://github.com/mgdigital/Chromaprint.scala) (reimplementation)
  * [C++/CLI](https://github.com/CyberSinh/Luminescence.Audio)
  * [Vala](https://github.com/GNOME/vala-extra-vapis/blob/master/libchromaprint.vapi)
+ * [Swift](https://github.com/wallisch/ChromaSwift)
 
 Integrations:
 


### PR DESCRIPTION
Hello,

Thank you for your amazing library & service!

I've created a [Swift package](https://github.com/wallisch/ChromaSwift) that can be used on macOS, iOS and tvOS via SPM.
It offers both a high level wrapper (ChromaSwift), including AcoustID lookup, as well as access to the C API from Swift (CChromaprint).

It would be nice if you could add it to the list of wrappers.

If you want, you could also host the [Package.swift](https://github.com/wallisch/ChromaSwift/blob/master/Package.swift) for CChromaprint in your repository, because it just contains the C/C++ build config.