### PR TITLE
Fix clang warnings on iOS/tvOS

### DIFF
--- a/src/audio_processor.cpp
+++ b/src/audio_processor.cpp
@@ -91,18 +91,18 @@ int AudioProcessor::Load(const int16_t *input, int length)
 void AudioProcessor::Resample()
 {
 	if (!m_resample_ctx) {
-		m_consumer->Consume(m_buffer.data(), m_buffer_offset);
+		m_consumer->Consume(m_buffer.data(), int(m_buffer_offset));
 		m_buffer_offset = 0;
 		return;
 	}
 	int consumed = 0;
-	int length = av_resample(m_resample_ctx, m_resample_buffer.data(), m_buffer.data(), &consumed, m_buffer_offset, kMaxBufferSize, 1);
+	int length = av_resample(m_resample_ctx, m_resample_buffer.data(), m_buffer.data(), &consumed, int(m_buffer_offset), kMaxBufferSize, 1);
 	if (length > kMaxBufferSize) {
 		DEBUG("chromaprint::AudioProcessor::Resample() -- Resampling overwrote output buffer.");
 		length = kMaxBufferSize;
 	}
 	m_consumer->Consume(m_resample_buffer.data(), length);
-	int remaining = m_buffer_offset - consumed;
+	int remaining = int(m_buffer_offset - consumed);
 	if (remaining > 0) {
 		std::copy(m_buffer.begin() + consumed, m_buffer.begin() + m_buffer_offset, m_buffer.begin());
 	}

--- a/src/chromaprint.cpp
+++ b/src/chromaprint.cpp
@@ -137,7 +137,7 @@ int chromaprint_get_raw_fingerprint(ChromaprintContext *ctx, uint32_t **data, in
 	const auto fingerprint = ctx->fingerprinter.GetFingerprint();
 	*data = (uint32_t *) malloc(sizeof(uint32_t) * fingerprint.size());
 	FAIL_IF(!*data, "can't allocate memory for the result");
-	*size = fingerprint.size();
+	*size = int(fingerprint.size());
 	std::copy(fingerprint.begin(), fingerprint.end(), *data);
 	return 1;
 }
@@ -146,7 +146,7 @@ int chromaprint_get_raw_fingerprint_size(ChromaprintContext *ctx, int *size)
 {
 	FAIL_IF(!ctx, "context can't be NULL");
 	const auto fingerprint = ctx->fingerprinter.GetFingerprint();
-	*size = fingerprint.size();
+	*size = int(fingerprint.size());
 	return 1;
 }
 
@@ -172,7 +172,7 @@ int chromaprint_encode_fingerprint(const uint32_t *fp, int size, int algorithm, 
 		encoded = Base64Encode(encoded);
 	}
 	*encoded_fp = (char *) malloc(encoded.size() + 1);
-	*encoded_size = encoded.size();	
+	*encoded_size = int(encoded.size());
 	std::copy(encoded.data(), encoded.data() + encoded.size() + 1, *encoded_fp);
 	return 1;
 }
@@ -195,7 +195,7 @@ int chromaprint_decode_fingerprint(const char *encoded_fp, int encoded_size, uin
 		return 0;
 	}
 	*fp = (uint32_t *) malloc(sizeof(uint32_t) * uncompressed.size());
-	*size = uncompressed.size();
+	*size = int(uncompressed.size());
 	if (algorithm) {
 		*algorithm = algo;
 	}

--- a/src/debug.h
+++ b/src/debug.h
@@ -12,6 +12,10 @@
 
 namespace chromaprint {
 
+#ifdef DEBUG
+#undef DEBUG
+#endif
+
 #ifdef NDEBUG
 #define DEBUG(x)
 #else

--- a/src/fingerprint_matcher.cpp
+++ b/src/fingerprint_matcher.cpp
@@ -116,7 +116,7 @@ bool FingerprintMatcher::Match(const uint32_t fp1_data[], size_t fp1_size, const
 	m_segments.clear();
 
 	for (const auto &item : m_best_alignments) {
-		const int offset_diff = item.second - fp2_size;
+		const int offset_diff = int(item.second - fp2_size);
 
 		const size_t offset1 = offset_diff > 0 ? offset_diff : 0;
 		const size_t offset2 = offset_diff < 0 ? -offset_diff : 0;

--- a/src/image.h
+++ b/src/image.h
@@ -60,7 +60,7 @@ public:
 	}
 
 	int NumColumns() const { return m_columns; }
-	int NumRows() const { return m_data.size() / m_columns; }
+	int NumRows() const { return int(m_data.size() / m_columns); }
 
 	void AddRow(const std::vector<double> &row)
 	{

--- a/src/include/chromaprint.h
+++ b/src/include/chromaprint.h
@@ -1,0 +1,1 @@
+../chromaprint.h

--- a/src/spectrum.h
+++ b/src/spectrum.h
@@ -22,7 +22,7 @@ public:
 	void Consume(const FFTFrame &frame);
 
 protected:
-	int NumBands() const { return m_bands.size() - 1; }
+	int NumBands() const { return int(m_bands.size() - 1); }
 	int FirstIndex(int band) const { return m_bands[band]; }
 	int LastIndex(int band) const { return m_bands[band + 1]; }
 


### PR DESCRIPTION
This fixes some implicit integer conversion warnings when compiling on clang for iOS/tvOS and adds a symlink to chromaprint.h to the default public header folder, which allows chromaprint to be compiled without any unsafe flags.