### PR TITLE
Fix build with FFmpeg 8.0

### DIFF
--- a/src/audio/ffmpeg_audio_reader.h
+++ b/src/audio/ffmpeg_audio_reader.h
@@ -224,10 +224,7 @@ inline void FFmpegAudioReader::Close() {
 
 	m_stream_index = -1;
 
-	if (m_codec_ctx) {
-		avcodec_close(m_codec_ctx);
-		m_codec_ctx = nullptr;
-	}
+	avcodec_free_context(&m_codec_ctx);
 
 	if (m_format_ctx) {
 		avformat_close_input(&m_format_ctx);


### PR DESCRIPTION
See https://github.com/FFmpeg/FFmpeg/commit/0d48da2db0b239d80c6e8b30e66211a977566588 for `avcodec_close()` removal in FFmpeg 8.0

The deprecation comment for `avcodec_close()` said:
> Do not use this function. Use avcodec_free_context() to destroy a
> codec context (either open or closed). Opening and closing a codec context
> multiple times is not supported anymore -- use multiple codec contexts
> instead.

`avcodec_free_context()` has been around since FFmpeg 2.3 (lavc 55.52.0, https://github.com/FFmpeg/FFmpeg/commit/fd056029f45a9f6d213d9fce8165632042511d4f). Seems old enough for most versions of FFmpeg is active use but can add conditional if older versions are needed.

Documentation at https://ffmpeg.org/doxygen/2.3/group__lavc__core.html#gaf869d0829ed607cec3a4a02a1c7026b3 says:
> Free the codec context and everything associated with it and write NULL to the provided pointer.
