### PR TITLE
support installing to absolute paths

### DIFF
--- a/libchromaprint.pc.cmake
+++ b/libchromaprint.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: Audio fingerprint library


### PR DESCRIPTION
Using `@CMAKE_INSTALL_FULL_*DIR@` instead of using `${prefix}/@CMAKE_INSTALL_*DIR@` makes it possible to install to absolute paths and not just relative paths. Which we need in nixpkgs to correctly build the package.