### PR TITLE
Fix implicit integer conversion warning in LLVM

### DIFF
--- a/src/simhash.cpp
+++ b/src/simhash.cpp
@@ -20,7 +20,7 @@ uint32_t SimHash(const uint32_t *data, size_t size)
 		}
 	}
 
-	const int threshold = size / 2;
+	const size_t threshold = size / 2;
 	uint32_t hash = 0;
 	for (size_t i = 0; i < 32; i++) {
 		const int b = v[i] > threshold ? 1 : 0;


### PR DESCRIPTION
Fixes the following warning emitted by LLVM:

`Implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'const int'`

Shows up in the Xcode UI when importing the Swift package (The underlying C code should ideally be invisible to the user).