### PR TITLE
AudioProcessor: don't abort() on a non-frame-aligned Consume()

### DIFF
--- a/src/audio_processor.cpp
+++ b/src/audio_processor.cpp
@@ -140,6 +140,7 @@ bool AudioProcessor::Reset(int sample_rate, int num_channels)
 		return false;
 	}
 	m_buffer_offset = 0;
+    m_leftover.clear();
 
 #if USE_INTERNAL_AVRESAMPLE
 	if (m_resample_ctx) {
@@ -168,16 +169,37 @@ bool AudioProcessor::Reset(int sample_rate, int num_channels)
 void AudioProcessor::Consume(const int16_t *input, int length)
 {
 	assert(length >= 0);
+	if (!m_leftover.empty()) {
+		while (length > 0 && static_cast<int>(m_leftover.size()) < m_num_channels) {
+			m_leftover.push_back(*input++);
+			length--;
+		}
+		if (static_cast<int>(m_leftover.size()) < m_num_channels) {
+			return;
+		}
+		ConsumeAligned(&m_leftover[0], m_num_channels);
+		m_leftover.clear();
+	}
+	const int remainder = length % m_num_channels;
+	ConsumeAligned(input, length - remainder);
+	if (remainder > 0) {
+		m_leftover.assign(input + length - remainder, input + length);
+	}
+}
+
+void AudioProcessor::ConsumeAligned(const int16_t *input, int length)
+{
+	assert(length >= 0);
 	assert(length % m_num_channels == 0);
 	length /= m_num_channels;
 	while (length > 0) {
-		int consumed = Load(input, length); 
+		int consumed = Load(input, length);
 		input += consumed * m_num_channels;
 		length -= consumed;
 		if (m_buffer.size() == m_buffer_offset) {
 			Resample();
 			if (m_buffer.size() == m_buffer_offset) {
-				DEBUG("chromaprint::AudioProcessor::Consume() -- Resampling failed?");
+				DEBUG("chromaprint::AudioProcessor::ConsumeAligned() -- Resampling failed?");
 				return;
 			}
 		}

--- a/src/audio_processor.h
+++ b/src/audio_processor.h
@@ -64,6 +64,9 @@ namespace chromaprint
 		std::vector<int16_t> m_resample_buffer;
 		int m_target_sample_rate;
 		int m_num_channels;
+        // Trailing partial frame carried over between Consume() calls when a
+        // caller splits its audio on non-frame boundaries.
+        std::vector<int16_t> m_leftover;
 		AudioConsumer *m_consumer;
 		struct AVResampleContext *m_resample_ctx;
 	};

--- a/src/audio_processor.h
+++ b/src/audio_processor.h
@@ -45,14 +45,13 @@ namespace chromaprint
 		//! Process a chunk of data from the audio stream
 		void Consume(const int16_t *input, int length);
 
-        void ConsumeAligned(const int16_t *input, int length);
-
 		//! Process any buffered input that was not processed before and clear buffers
 		void Flush();
 
 	private:
 		CHROMAPRINT_DISABLE_COPY(AudioProcessor);
 
+        void ConsumeAligned(const int16_t *input, int length);
 		int Load(const int16_t *input, int length);
 		void LoadMono(const int16_t *input, int length);
 		void LoadStereo(const int16_t *input, int length);

--- a/src/audio_processor.h
+++ b/src/audio_processor.h
@@ -45,6 +45,8 @@ namespace chromaprint
 		//! Process a chunk of data from the audio stream
 		void Consume(const int16_t *input, int length);
 
+        void ConsumeAligned(const int16_t *input, int length);
+
 		//! Process any buffered input that was not processed before and clear buffers
 		void Flush();
 


### PR DESCRIPTION
Fixes [#90](https://github.com/music-assistant/server/issues/90).

`AudioProcessor::Consume()` asserts that the input length is a whole multiple
of the channel count:

```cpp
assert(length % m_num_channels == 0);
```

When a caller passes a buffer that splits the audio mid-frame, this assertion aborts the entire host process instead of failing gracefully. It's easy to hit when feeding PCM in fixed-size byte chunks (the chunk boundary rarely lands
on a frame boundary), and especially likely with multi-channel sources where a frame spans more bytes. A library should never abort() the process that embeds it on account of input framing.

Reported downstream where an AcoustID scan of a 5.1 file took the whole application down with:

Assertion `length % m_num_channels == 0` failed.

`Consume()` now tolerates input that isn't aligned to a whole number of frames. Any trailing partial frame is buffered in a new m_leftover member and prepended to the next call, so the audio is processed losslessly and channel
interleaving stays aligned across calls. The existing whole-frame processing loop is unchanged, it's simply moved into a private `ConsumeAligned()` helper that `Consume()` calls once the input has been split into a whole-frame portion
and a carried remainder.

`Consume()` splits input into complete frames + a carried remainder` ConsumeAligned()` the original `Consume()` body (still asserts alignment, which is now always satisfied) `m_leftover` holds a sub-frame remainder between calls; cleared in `Reset()` Behaviour for callers that already pass whole frames is identical as the leftover buffer stays empty, remainder is always 0, and the exact same processing path runs.